### PR TITLE
Wrapping the notFound import in curly braces in category subfolder

### DIFF
--- a/src/app/portfolio/[category]/page.jsx
+++ b/src/app/portfolio/[category]/page.jsx
@@ -2,7 +2,7 @@
 import { Button } from '@/components/Button/Button';
 import Image from 'next/image';
 import React from 'react';
-import notFound from 'next/navigation';
+import { notFound } from 'next/navigation';
 
 import beachPic from '../../../../public/beach_pic.jpeg';
 import { items } from './data';


### PR DESCRIPTION
Wrapped the notFound import from next/navigation in curly braces for it to work properly and navigate to a 404 page if a route does not exist.